### PR TITLE
Debug undefined map in onStart transform

### DIFF
--- a/onStart_script_fixed.js
+++ b/onStart_script_fixed.js
@@ -1,0 +1,110 @@
+// It appears there might be a scoping issue with how the 'map' object is being passed.
+// This version removes the function wrapper to simplify the script and rely directly on the globally available transform script objects.
+// It also adds a check to ensure the 'map' object exists before proceeding.
+
+// Global variables to use in field map, onBefore and onComplete
+TEST_RUN = false; // used by onBefore: if True, process only 20 rows for testing purposes
+TEST_RUN_MAX_ROWS = 20;
+SERIAL_NUMBER_SOURCE = 'u_serienr'; //name of field in import table for Serial Number
+CATEGORY_SOURCE = 'u_computacenter_category';
+SUB_CATEGORY_SOURCE = 'u_cmdb_cat_';
+DESCRIPTION_SOURCE = 'u_omschrijving';
+TAG_SOURCE = 'u_tagnr';
+
+// Put all of the above global variables with source table field names in this array
+SOURCE_FIELD_NAMES = [SERIAL_NUMBER_SOURCE, CATEGORY_SOURCE, SUB_CATEGORY_SOURCE, DESCRIPTION_SOURCE, TAG_SOURCE];
+
+//*** DO NOT CHANGE ANYTHING BELOW ***//
+DATE_TODAY = new GlideDateTime(); // used by onBefore
+DATE_TODAY.setValue(gs.beginningOfToday());
+
+// Set and check global vars for Transform Maps for Mutatielijst and Voorraadlijst
+IMPORT_ROW_SOURCE = '';
+IMPORT_TABLE = '';
+TARGET_TABLE = '';
+MODEL_ALREADY_CHECKED = [];
+ATTENTION_FIELDS_EXIST = false;
+MISCO_CATEGORIES_TO_IMPORT = [];
+SERIAL_NUMBER = '';
+NEW_APPLE_DEVICES = [];
+REASON_ATTENTION_NOT_IN_STOCK = '';
+DUPLICATE_ROWS_TO_IGNORE = []; // Initialize global variable
+
+// This function will filter out the first occurrence of an item with a given key,
+// leaving only the subsequent duplicates. Because the query is sorted, this means
+// we keep the older import rows to be ignored.
+function removeFirstOccurence(arr, key) {
+    var processed = {};
+    return arr.filter(function(item) {
+        if (processed.hasOwnProperty(item[key])) {
+            return true;
+        }
+        processed[item[key]] = true;
+        return false;
+    });
+}
+
+
+// Check if map object is defined before using it.
+if (typeof map === 'undefined' || map === null) {
+    log.error("The 'map' object is not available in the onStart transform script. Aborting transform.");
+    error = true; // Abort the transform
+} else {
+    var assetManagement = new global.asrAssetManagement();
+    assetManagement.performSharedOnStartTasks(map);
+
+    if (assetManagement.error) {
+        var errorMessage = assetManagement.getError();
+        log.error("Error during onStart script execution: " + errorMessage);
+        error = true; //abort import
+    }
+
+    // De-duplication logic only runs if there are no errors so far
+    if (!error) {
+        // GlideQuery all Rows in import table of current Import Set
+        var duplicateSerialsGQ = new GlideQuery(IMPORT_TABLE)
+            .where('sys_import_set', import_set.sys_id.toString());
+
+        // Put in array: Serials that are found more than once
+        var duplicateSerials = [];
+        duplicateSerialsGQ
+            .aggregate('count', SERIAL_NUMBER_SOURCE)
+            .groupBy(SERIAL_NUMBER_SOURCE)
+            .having('count', SERIAL_NUMBER_SOURCE, '>', 1)
+            .select()
+            .forEach(function(g) {
+                duplicateSerials.push(g.group[SERIAL_NUMBER_SOURCE]);
+            });
+
+        // Put in array: object with these Serials and their import set Row
+        var duplicateSerialsWithRow = [];
+        if (duplicateSerials.length > 0) {
+            var rowsGQ = new GlideQuery(IMPORT_TABLE)
+                .where('sys_import_set', import_set.sys_id.toString())
+                .orderByDesc(SERIAL_NUMBER_SOURCE)
+                .orderByDesc(IMPORT_ROW_SOURCE)
+                .where(SERIAL_NUMBER_SOURCE, 'IN', duplicateSerials)
+                .select(SERIAL_NUMBER_SOURCE, IMPORT_ROW_SOURCE)
+                .forEach(function(g) {
+                    var obj = {
+                        serial: g[SERIAL_NUMBER_SOURCE],
+                        row: g[IMPORT_ROW_SOURCE]
+                    };
+                    duplicateSerialsWithRow.push(obj);
+                });
+        }
+
+        // Remove the Serial/Row combination that we want to process: the objects containing Serials/Rows to ignore remain
+        var serialsWithRowsToIgnore = removeFirstOccurence(duplicateSerialsWithRow, 'serial');
+
+        // Put in global array to use in rest of transform scripts: the Rows to ignore
+        var duplicateRowsToIgnoreArr = serialsWithRowsToIgnore.map(function(element) {
+            return element.row;
+        });
+
+        if (duplicateRowsToIgnoreArr.length > 0) {
+            var au = new ArrayUtil();
+            DUPLICATE_ROWS_TO_IGNORE = au.convertArray(duplicateRowsToIgnoreArr);
+        }
+    }
+}

--- a/sys_script_include_091238fadb9c0410b15bfd871d9619b1.xml
+++ b/sys_script_include_091238fadb9c0410b15bfd871d9619b1.xml
@@ -644,7 +644,6 @@ asrAssetManagement.prototype = Object.extendsObject(asrBaseClass, {
 	*/
 	performSharedOnStartTasks: function(map){
 		try{
-			gs.info(JSON.stringify(map, null, 2));
 			// GLOBAL vars must already be defined in the onStart itself, to be able to use them in the other Transform Map scripts
 			// checks for undefined sadly almost defies the purpose of this performSharedOnStartTasks() function, but alas
 			if(typeof SERIAL_NUMBER_SOURCE === 'undefined' || typeof CATEGORY_SOURCE === 'undefined' || typeof SUB_CATEGORY_SOURCE === 'undefined' || typeof DESCRIPTION_SOURCE === 'undefined' || typeof TAG_SOURCE === 'undefined' || typeof SOURCE_FIELD_NAMES === 'undefined' || typeof DATE_TODAY === 'undefined' || typeof TEST_RUN === 'undefined' || typeof TEST_RUN_MAX_ROWS === 'undefined' || typeof IMPORT_ROW_SOURCE === 'undefined' || typeof IMPORT_TABLE === 'undefined' || typeof TARGET_TABLE === 'undefined' || typeof MODEL_ALREADY_CHECKED === 'undefined' || typeof ATTENTION_FIELDS_EXIST === 'undefined' || typeof MISCO_CATEGORIES_TO_IMPORT === 'undefined' || typeof SERIAL_NUMBER === 'undefined' || typeof REASON_ATTENTION_NOT_IN_STOCK === 'undefined'){

--- a/sys_script_include_091238fadb9c0410b15bfd871d9619b1.xml
+++ b/sys_script_include_091238fadb9c0410b15bfd871d9619b1.xml
@@ -639,11 +639,12 @@ asrAssetManagement.prototype = Object.extendsObject(asrBaseClass, {
 	/**SNDOC
 	@name performSharedOnStartTasks
 	@description onStart transform script code shared by transform maps Mutatielijst and Voorraadlijst. Sets and checks global vars used throughout these imports.
-	@param {record} [log] - OOTB 'map' object from the current import run (exists within Transform Scripts).
+	@param {object} [map] - OOTB 'map' object from the current import run (exists within Transform Scripts).
 	@returns {boolean / string / nothing} Nothing if all is good, otherwise error = true + error message
 	*/
 	performSharedOnStartTasks: function(map){
 		try{
+			gs.info(JSON.stringify(map, null, 2));
 			// GLOBAL vars must already be defined in the onStart itself, to be able to use them in the other Transform Map scripts
 			// checks for undefined sadly almost defies the purpose of this performSharedOnStartTasks() function, but alas
 			if(typeof SERIAL_NUMBER_SOURCE === 'undefined' || typeof CATEGORY_SOURCE === 'undefined' || typeof SUB_CATEGORY_SOURCE === 'undefined' || typeof DESCRIPTION_SOURCE === 'undefined' || typeof TAG_SOURCE === 'undefined' || typeof SOURCE_FIELD_NAMES === 'undefined' || typeof DATE_TODAY === 'undefined' || typeof TEST_RUN === 'undefined' || typeof TEST_RUN_MAX_ROWS === 'undefined' || typeof IMPORT_ROW_SOURCE === 'undefined' || typeof IMPORT_TABLE === 'undefined' || typeof TARGET_TABLE === 'undefined' || typeof MODEL_ALREADY_CHECKED === 'undefined' || typeof ATTENTION_FIELDS_EXIST === 'undefined' || typeof MISCO_CATEGORIES_TO_IMPORT === 'undefined' || typeof SERIAL_NUMBER === 'undefined' || typeof REASON_ATTENTION_NOT_IN_STOCK === 'undefined'){


### PR DESCRIPTION
Refactor `onStart` transform script to resolve `map` object being undefined and improve de-duplication logic.

The `map` object was consistently `undefined` within the `onStart` transform script, preventing proper execution. This was likely due to a scoping issue caused by an unnecessary outer function wrapper. The changes remove this wrapper, add explicit checks for `map`, and refine the de-duplication process for robustness.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-a64c0d88-4113-4ff2-9fe5-e8711e1be98e) · [Cursor](https://cursor.com/background-agent?bcId=bc-a64c0d88-4113-4ff2-9fe5-e8711e1be98e)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)